### PR TITLE
Caliburn Altars Lava Death Fix

### DIFF
--- a/Tiles/CaliburnAltar.cs
+++ b/Tiles/CaliburnAltar.cs
@@ -24,6 +24,8 @@ namespace SGAmod.Tiles
             TileObjectData.newTile.CoordinateHeights = new int[] { 16, 16, 18 };
             TileObjectData.newTile.AnchorBottom = new AnchorData(AnchorType.SolidTile | AnchorType.SolidWithTop | AnchorType.SolidSide, TileObjectData.newTile.Width, 0);
             TileObjectData.newTile.StyleHorizontal = false;
+            TileObjectData.newTile.LavaDeath = false;
+            TileObjectData.newTile.WaterDeath = false;
             TileID.Sets.CanBeClearedDuringGeneration[Type] = false;
             //TileObjectData.newTile.HookPostPlaceMyPlayer = new PlacementHook(ModContent.GetInstance<BannerRackTE>().Hook_AfterPlacement, -1, 0, true);
             //TileObjectData.newTile.StyleWrapLimit = 36;
@@ -161,6 +163,8 @@ namespace SGAmod.Tiles
             TileObjectData.newTile.CoordinateHeights = new int[] { 16, 16, 20 };
             TileObjectData.newTile.AnchorBottom = new AnchorData(AnchorType.SolidTile | AnchorType.SolidWithTop | AnchorType.SolidSide, TileObjectData.newTile.Width, 0);
             TileObjectData.newTile.StyleHorizontal = false;
+            TileObjectData.newTile.LavaDeath = false;
+            TileObjectData.newTile.WaterDeath = false;
             //TileObjectData.newTile.StyleWrapLimit = 36;
             TileObjectData.addTile(Type);
             ModTranslation name = CreateMapEntryName();
@@ -185,6 +189,8 @@ namespace SGAmod.Tiles
             TileObjectData.newTile.CoordinateHeights = new int[] { 16, 16, 20 };
             TileObjectData.newTile.AnchorBottom = new AnchorData(AnchorType.SolidTile | AnchorType.SolidWithTop | AnchorType.SolidSide, TileObjectData.newTile.Width, 0);
             TileObjectData.newTile.StyleHorizontal = false;
+            TileObjectData.newTile.LavaDeath = false;
+            TileObjectData.newTile.WaterDeath = false;
             //TileObjectData.newTile.StyleWrapLimit = 36;
             TileObjectData.addTile(Type);
             ModTranslation name = CreateMapEntryName();


### PR DESCRIPTION
Added LavaDeath = false and WaterDeath = false so the altars wouldn't get destroyed by liquids.